### PR TITLE
Change misleading message when disabling DHCP hostname transfer

### DIFF
--- a/F31.sh
+++ b/F31.sh
@@ -77,11 +77,11 @@ else
     exit 1
 fi
 # Disable hostname through DHCP
-echo -e "\n${YELLOW}[+] Enabling hostname transfer via DHCP${NC}"
+echo -e "\n${YELLOW}[+] Disabling hostname transfer via DHCP${NC}"
 if sed -i '/\[ipv4\]/a dhcp-send-hostname=false' /etc/NetworkManager/system-connections/Wired\ connection\ 1; then
     echo -e "${GREEN}[*] Hostname through DHCP disabled successfully.${NC}"
 else
-    echo -e "${RED}[!] Error enabling hostname through DHCP.${NC}"
+    echo -e "${RED}[!] Error disabling hostname through DHCP.${NC}"
     exit 1
 fi
 


### PR DESCRIPTION
A simple pull request fixing a small typo when disabling DHCP hostname transfer.